### PR TITLE
Revise timestamp endpoint to match the client side changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A sync server implemented in go to communicate with Brave sync clients using
 Current Chromium version for sync protocol buffer files used in this repo is Chromium 83.0.4103.61.
 
 This server supports endpoints as bellow.
-1) The `GET /v2/timestamp` endpoint returns a UNIX timestamp in milliseconds and expected time for a token to expire in JSON format. Sync clients are responsible to create valid access tokens using timestamps returned by the server.
+1) The `POST /v2/timestamp` endpoint returns a UNIX timestamp in milliseconds and expected time for a token to expire in JSON format. Sync clients are responsible to create valid access tokens using timestamps returned by the server.
 2) The `POST /v2/command/` endpoint handles Commit and GetUpdates requests from sync clients and return corresponding responses both in protobuf format. Detailed of requests and their corresponding responses are defined in `sync_pb/sync.proto`. Previous granted access token should be passed in the request's Authorization header.
 
 Currently we use dynamoDB as the datastore, the schema could be found in `schema/dynamodb/table.json`.

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -26,7 +26,7 @@ const (
 func SyncRouter(datastore datastore.Datastore) chi.Router {
 	r := chi.NewRouter()
 	r.Method("POST", "/command/", middleware.InstrumentHandler("Command", Command(datastore)))
-	r.Method("GET", "/timestamp", middleware.InstrumentHandler("Timetamp", Timestamp()))
+	r.Method("POST", "/timestamp", middleware.InstrumentHandler("Timetamp", Timestamp()))
 	return r
 }
 

--- a/schema/json/timestamp.go
+++ b/schema/json/timestamp.go
@@ -2,6 +2,8 @@ package json
 
 // TimestampResponse is a structure used for timestamp responses.
 type TimestampResponse struct {
-	Timestamp string `json:"timestamp"`
+	// Client will compose the actual token from it, it's named access_token to
+	// avoid patching into chromium on client side.
+	Timestamp string `json:"access_token"`
 	ExpiresIn int64  `json:"expires_in"`
 }

--- a/timestamp/timestamp_test.go
+++ b/timestamp/timestamp_test.go
@@ -20,6 +20,6 @@ func TestGetTimestamp(t *testing.T) {
 	err = json.Unmarshal(rsp, &timestampRsp)
 	assert.Nil(t, err)
 
-	expectedJSON := "{\"timestamp\":\"" + timestampRsp.Timestamp + "\",\"expires_in\":" + strconv.FormatInt(auth.TokenMaxDuration, 10) + "}"
+	expectedJSON := "{\"access_token\":\"" + timestampRsp.Timestamp + "\",\"expires_in\":" + strconv.FormatInt(auth.TokenMaxDuration, 10) + "}"
 	assert.Equal(t, expectedJSON, string(rsp))
 }


### PR DESCRIPTION
Below changes are made in this PR to avoid patching into chromium on client side.
1. Use `POST v2/timestamp` instead of `GET v2/timestamp`.
2. Change the json key from timestamp to access_token.

Fix https://github.com/brave/go-sync/issues/9