### PR TITLE
Add ResponseHeader middleware to provide Sane-Time-Millis in response headers

### DIFF
--- a/middleware/response_header.go
+++ b/middleware/response_header.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/brave/go-sync/utils"
+)
+
+const (
+	saneTimeMillsHeaderKey = "Sane-Time-Millis"
+)
+
+// ResponseHeader is a middleware to apply common response headers.
+func ResponseHeader(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(saneTimeMillsHeaderKey,
+			strconv.FormatInt(utils.UnixMilli(time.Now()), 10))
+		next.ServeHTTP(w, r)
+	})
+}

--- a/middleware/response_header.go
+++ b/middleware/response_header.go
@@ -8,15 +8,23 @@ import (
 	"github.com/brave/go-sync/utils"
 )
 
-const (
-	saneTimeMillsHeaderKey = "Sane-Time-Millis"
+func saneTimeMillsHeaderFunc(w http.ResponseWriter) {
+	w.Header().Set("Sane-Time-Millis", strconv.FormatInt(utils.UnixMilli(time.Now()), 10))
+}
+
+var (
+	headerFuncs = []func(w http.ResponseWriter){
+		saneTimeMillsHeaderFunc,
+	}
 )
 
-// ResponseHeader is a middleware to apply common response headers.
-func ResponseHeader(next http.Handler) http.Handler {
+// CommonResponseHeaders is a middleware to apply common response headers.
+func CommonResponseHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(saneTimeMillsHeaderKey,
-			strconv.FormatInt(utils.UnixMilli(time.Now()), 10))
+		for _, headerFunc := range headerFuncs {
+			headerFunc(w)
+		}
+
 		next.ServeHTTP(w, r)
 	})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -42,7 +42,7 @@ func setupRouter(ctx context.Context, logger *zerolog.Logger) (context.Context, 
 
 	r.Use(chiware.Timeout(60 * time.Second))
 	r.Use(batware.BearerToken)
-	r.Use(middleware.ResponseHeader)
+	r.Use(middleware.CommonResponseHeaders)
 
 	db, err := datastore.NewDynamo()
 	if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/brave/go-sync/server"
 	"github.com/go-chi/chi"
+	"github.com/stretchr/testify/assert"
 )
 
 var handler http.Handler
@@ -20,21 +21,25 @@ func init() {
 }
 
 func TestPing(t *testing.T) {
-	server := httptest.NewServer(handler)
-	defer server.Close()
-	resp, err := http.Get(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("Received non-200 response: %d\n", resp.StatusCode)
-	}
+	req, err := http.NewRequest("GET", "/", nil)
+	assert.Nil(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
 	expected := "."
-	actual, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if expected != string(actual) {
-		t.Errorf("Expected the message '%s'\n", expected)
-	}
+	actual, err := ioutil.ReadAll(rr.Result().Body)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, string(actual))
+}
+
+func TestTimestamp(t *testing.T) {
+	req, err := http.NewRequest("POST", "/v2/timestamp", nil)
+	assert.Nil(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.NotEmpty(t, rr.Result().Header.Get("Sane-Time-Millis"))
 }


### PR DESCRIPTION
Fix https://github.com/brave/go-sync/issues/12