### PR TITLE
Release 06/05/2020

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 FROM golang:1.14 as builder
 
+ARG VERSION
+ARG BUILD_TIME
+ARG COMMIT
+
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go build -o main .
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags "-X github.com/brave/go-sync/server.version=${VERSION} -X github.com/brave/go-sync/server.buildTime=${BUILD_TIME} -X github.com/brave/go-sync/server.commit=${COMMIT}" \
+    -o main .
 
 FROM alpine:3.6 as artifact
 RUN apk add --update ca-certificates # Certificates for SSL

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+GIT_VERSION := $(shell git describe --abbrev=8 --dirty --always --tags)
+GIT_COMMIT := $(shell git rev-parse --short HEAD)
+BUILD_TIME := $(shell date +%s)
+
 .PHONY: all build test lint clean
 
 all: lint test build
@@ -18,13 +22,13 @@ clean:
 	rm -f sync-server
 
 docker:
-	docker-compose build
+	COMMIT=$(GIT_COMMIT) VERSION=$(GIT_VERSION) BUILD_TIME=$(BUILD_TIME) docker-compose build
 
 docker-up:
-	docker-compose up
+	COMMIT=$(GIT_COMMIT) VERSION=$(GIT_VERSION) BUILD_TIME=$(BUILD_TIME) docker-compose up
 
 docker-test:
-	docker-compose -f docker-compose.yml run --rm dev make test
+	COMMIT=$(GIT_COMMIT) VERSION=$(GIT_VERSION) BUILD_TIME=$(BUILD_TIME) docker-compose -f docker-compose.yml run --rm dev make test
 
 instrumented:
 	gowrap gen -p github.com/brave/go-sync/datastore -i Datastore -t ./.prom-gowrap.tmpl -o ./datastore/instrumented_datastore.go

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A sync server implemented in go to communicate with Brave sync clients using
 Current Chromium version for sync protocol buffer files used in this repo is Chromium 83.0.4103.61.
 
 This server supports endpoints as bellow.
-1) The `GET /v2/timestamp` endpoint returns a UNIX timestamp in milliseconds and expected time for a token to expire in JSON format. Sync clients are responsible to create valid access tokens using timestamps returned by the server.
+1) The `POST /v2/timestamp` endpoint returns a UNIX timestamp in milliseconds and expected time for a token to expire in JSON format. Sync clients are responsible to create valid access tokens using timestamps returned by the server.
 2) The `POST /v2/command/` endpoint handles Commit and GetUpdates requests from sync clients and return corresponding responses both in protobuf format. Detailed of requests and their corresponding responses are defined in `sync_pb/sync.proto`. Previous granted access token should be passed in the request's Authorization header.
 
 Currently we use dynamoDB as the datastore, the schema could be found in `schema/dynamodb/table.json`.

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -26,7 +26,7 @@ const (
 func SyncRouter(datastore datastore.Datastore) chi.Router {
 	r := chi.NewRouter()
 	r.Method("POST", "/command/", middleware.InstrumentHandler("Command", Command(datastore)))
-	r.Method("GET", "/timestamp", middleware.InstrumentHandler("Timetamp", Timestamp()))
+	r.Method("POST", "/timestamp", middleware.InstrumentHandler("Timetamp", Timestamp()))
 	return r
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
     build:
       context: .
       target: builder
+      args:
+        VERSION: "${VERSION}"
+        COMMIT: "${COMMIT}"
+        BUILD_TIME: "${BUILD_TIME}"
     depends_on:
       - dynamo-local
     networks:
@@ -26,6 +30,10 @@ services:
     build:
       context: .
       target: artifact
+      args:
+        VERSION: "${VERSION}"
+        COMMIT: "${COMMIT}"
+        BUILD_TIME: "${BUILD_TIME}"
     ports:
       - "8295:8295"
     depends_on:

--- a/middleware/response_header.go
+++ b/middleware/response_header.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/brave/go-sync/utils"
+)
+
+func saneTimeMillsHeaderFunc(w http.ResponseWriter) {
+	w.Header().Set("Sane-Time-Millis", strconv.FormatInt(utils.UnixMilli(time.Now()), 10))
+}
+
+var (
+	headerFuncs = []func(w http.ResponseWriter){
+		saneTimeMillsHeaderFunc,
+	}
+)
+
+// CommonResponseHeaders is a middleware to apply common response headers.
+func CommonResponseHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, headerFunc := range headerFuncs {
+			headerFunc(w)
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/schema/json/timestamp.go
+++ b/schema/json/timestamp.go
@@ -2,6 +2,8 @@ package json
 
 // TimestampResponse is a structure used for timestamp responses.
 type TimestampResponse struct {
-	Timestamp string `json:"timestamp"`
+	// Client will compose the actual token from it, it's named access_token to
+	// avoid patching into chromium on client side.
+	Timestamp string `json:"access_token"`
 	ExpiresIn int64  `json:"expires_in"`
 }

--- a/server/server.go
+++ b/server/server.go
@@ -7,11 +7,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/brave-intl/bat-go/middleware"
+	batware "github.com/brave-intl/bat-go/middleware"
 	appctx "github.com/brave-intl/bat-go/utils/context"
 	"github.com/brave-intl/bat-go/utils/logging"
 	"github.com/brave/go-sync/controller"
 	"github.com/brave/go-sync/datastore"
+	"github.com/brave/go-sync/middleware"
 	"github.com/getsentry/sentry-go"
 	"github.com/go-chi/chi"
 	chiware "github.com/go-chi/chi/middleware"
@@ -36,11 +37,12 @@ func setupRouter(ctx context.Context, logger *zerolog.Logger) (context.Context, 
 		r.Use(hlog.NewHandler(*logger))
 		r.Use(hlog.UserAgentHandler("user_agent"))
 		r.Use(hlog.RequestIDHandler("req_id", "Request-Id"))
-		r.Use(middleware.RequestLogger(logger))
+		r.Use(batware.RequestLogger(logger))
 	}
 
 	r.Use(chiware.Timeout(60 * time.Second))
-	r.Use(middleware.BearerToken)
+	r.Use(batware.BearerToken)
+	r.Use(middleware.CommonResponseHeaders)
 
 	db, err := datastore.NewDynamo()
 	if err != nil {
@@ -50,7 +52,7 @@ func setupRouter(ctx context.Context, logger *zerolog.Logger) (context.Context, 
 
 	r.Mount("/v2", controller.SyncRouter(
 		datastore.NewDatastoreWithPrometheus(db, "dynamo")))
-	r.Get("/metrics", middleware.Metrics())
+	r.Get("/metrics", batware.Metrics())
 
 	// Add profiling flag to enable profiling routes.
 	if os.Getenv("PPROF_ENABLED") != "" {

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	_ "net/http/pprof" // pprof magic
 	"os"
@@ -9,6 +10,7 @@ import (
 
 	batware "github.com/brave-intl/bat-go/middleware"
 	appctx "github.com/brave-intl/bat-go/utils/context"
+	"github.com/brave-intl/bat-go/utils/handlers"
 	"github.com/brave-intl/bat-go/utils/logging"
 	"github.com/brave/go-sync/controller"
 	"github.com/brave/go-sync/datastore"
@@ -19,6 +21,12 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/hlog"
 	"github.com/rs/zerolog/log"
+)
+
+var (
+	commit    string
+	version   string
+	buildTime string
 )
 
 func setupLogger(ctx context.Context) (context.Context, *zerolog.Logger) {
@@ -54,6 +62,13 @@ func setupRouter(ctx context.Context, logger *zerolog.Logger) (context.Context, 
 		datastore.NewDatastoreWithPrometheus(db, "dynamo")))
 	r.Get("/metrics", batware.Metrics())
 
+	log.Info().
+		Str("version", version).
+		Str("commit", commit).
+		Str("buildTime", buildTime).
+		Msg("server starting up")
+	r.Get("/health-check", handlers.HealthCheckHandler(version, buildTime, commit))
+
 	// Add profiling flag to enable profiling routes.
 	if os.Getenv("PPROF_ENABLED") != "" {
 		// pprof attaches routes to default serve mux
@@ -73,7 +88,10 @@ func StartServer() {
 	// Setup Sentry.
 	sentryDsn := os.Getenv("SENTRY_DSN")
 	if sentryDsn != "" {
-		err := sentry.Init(sentry.ClientOptions{Dsn: sentryDsn})
+		err := sentry.Init(sentry.ClientOptions{
+			Dsn:     sentryDsn,
+			Release: fmt.Sprintf("go-sync@%s-%s", commit, buildTime),
+		})
 		if err != nil {
 			logger.Panic().Err(err).Msg("Init sentry failed")
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/brave/go-sync/server"
 	"github.com/go-chi/chi"
+	"github.com/stretchr/testify/assert"
 )
 
 var handler http.Handler
@@ -20,21 +21,25 @@ func init() {
 }
 
 func TestPing(t *testing.T) {
-	server := httptest.NewServer(handler)
-	defer server.Close()
-	resp, err := http.Get(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("Received non-200 response: %d\n", resp.StatusCode)
-	}
+	req, err := http.NewRequest("GET", "/", nil)
+	assert.Nil(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
 	expected := "."
-	actual, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if expected != string(actual) {
-		t.Errorf("Expected the message '%s'\n", expected)
-	}
+	actual, err := ioutil.ReadAll(rr.Result().Body)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, string(actual))
+}
+
+func TestTimestamp(t *testing.T) {
+	req, err := http.NewRequest("POST", "/v2/timestamp", nil)
+	assert.Nil(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.NotEmpty(t, rr.Result().Header.Get("Sane-Time-Millis"))
 }

--- a/timestamp/timestamp_test.go
+++ b/timestamp/timestamp_test.go
@@ -20,6 +20,6 @@ func TestGetTimestamp(t *testing.T) {
 	err = json.Unmarshal(rsp, &timestampRsp)
 	assert.Nil(t, err)
 
-	expectedJSON := "{\"timestamp\":\"" + timestampRsp.Timestamp + "\",\"expires_in\":" + strconv.FormatInt(auth.TokenMaxDuration, 10) + "}"
+	expectedJSON := "{\"access_token\":\"" + timestampRsp.Timestamp + "\",\"expires_in\":" + strconv.FormatInt(auth.TokenMaxDuration, 10) + "}"
 	assert.Equal(t, expectedJSON, string(rsp))
 }


### PR DESCRIPTION
Include PRs:
- #10 Delete tag item when the matching sync item is being soft-deleted.
- #11 Revise timestamp endpoint to match the client side changes.
- #13 Add ResponseHeader middleware to provide Sane-Time-Millis in response headers
- #15 Add health-check endpoint