### PR TITLE
Fix changes remaining

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -80,18 +80,30 @@ func handleGetUpdatesRequest(guMsg *sync_pb.GetUpdatesMessage, guRsp *sync_pb.Ge
 			guRsp.EncryptionKeys[0] = []byte("1234")
 		}
 
+		// No need to get updates for this type because we already reach the
+		// maximum GetUpdates size for this request. Continue to next type instead
+		// of break because we need to prepare NewProgressMarker for all entries in
+		// FromProgressMarker, where the returned token stays the same as the one
+		// passed in FromProgressMarker.
+		if int32(len(guRsp.Entries)) >= maxSize {
+			continue
+		}
+
 		token, n := binary.Varint(guRsp.NewProgressMarker[i].Token)
 		if n <= 0 {
 			return nil, fmt.Errorf("Failed at decoding token value %v", token)
 		}
 
 		curMaxSize := int64(maxSize) - int64(len(guRsp.Entries))
-		count, entities, err := db.GetUpdatesForType(int(*fromProgressMarker.DataTypeId), token, fetchFolders, clientID, curMaxSize)
+		hasChangesRemaining, entities, err := db.GetUpdatesForType(int(*fromProgressMarker.DataTypeId), token, fetchFolders, clientID, curMaxSize)
 		if err != nil {
 			log.Error().Err(err).Msgf("db.GetUpdatesForType failed for type %v", *fromProgressMarker.DataTypeId)
 			errCode = sync_pb.SyncEnums_TRANSIENT_ERROR
 			return &errCode,
 				fmt.Errorf("error getting updates for type %v: %w", *fromProgressMarker.DataTypeId, err)
+		}
+		if hasChangesRemaining {
+			changesRemaining = 1 // Chromium uses 1 instead of actual count of update entries remaining.
 		}
 
 		// Fill the PB entry from above DB entries until maxSize is reached.
@@ -104,9 +116,6 @@ func handleGetUpdatesRequest(guMsg *sync_pb.GetUpdatesMessage, guRsp *sync_pb.Ge
 			}
 			guRsp.Entries = append(guRsp.Entries, entity)
 		}
-		// Add to changesRemaining if this type has some items left due to batchSize.
-		changesRemaining = count - int64(len(entities))
-
 		// If entities are appended, use the lastest mtime as returned token.
 		if j != 0 {
 			guRsp.NewProgressMarker[i].Token = make([]byte, binary.MaxVarintLen64)

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -414,8 +414,7 @@ func (suite *CommandTestSuite) TestHandleClientToServerMessage_GUBatchSize() {
 		"HandleClientToServerMessage should succeed")
 	assertCommonResponse(suite, rsp, false)
 	suite.Assert().Equal(int(*command.MaxGUBatchSize), len(rsp.GetUpdates.Entries))
-	suite.Assert().Equal(int64(len(entries)-int(*command.MaxGUBatchSize)),
-		*rsp.GetUpdates.ChangesRemaining)
+	suite.Assert().Equal(int64(1), *rsp.GetUpdates.ChangesRemaining)
 	// nigori1, nigori2
 	expectedName = []*string{entries[1].Name, entries[3].Name}
 	for i, entry := range rsp.GetUpdates.Entries {

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -9,12 +9,10 @@ type Datastore interface {
 	// Update an existing sync entity.
 	UpdateSyncEntity(entity *SyncEntity) (conflict bool, delete bool, err error)
 	// Get updates for a specific type which are modified after the time of
-	// client token for a given client. The total count of the updates available
-	// in the DB would also be returned, which might not be the same as the
-	// length of the returned SyncEntity slice if the total count is greater than
-	// the maxSize parameter, in that case, length of the returned SyncEntity
-	// slice would be maxSize.
-	GetUpdatesForType(dataType int, clientToken int64, fetchFolders bool, clientID string, maxSize int64) (int64, []SyncEntity, error)
+	// client token for a given client. Besides the array of sync entities, a
+	// boolean value indicating whether there are more updates to query in the
+	// next batch is returned.
+	GetUpdatesForType(dataType int, clientToken int64, fetchFolders bool, clientID string, maxSize int64) (bool, []SyncEntity, error)
 	// Check if a server-defined unique tag is in the datastore.
 	HasServerDefinedUniqueTag(clientID string, tag string) (bool, error)
 	// Get the count of sync items for a client.

--- a/datastore/instrumented_datastore.go
+++ b/datastore/instrumented_datastore.go
@@ -52,7 +52,7 @@ func (_d DatastoreWithPrometheus) GetClientItemCount(clientID string) (i1 int, e
 }
 
 // GetUpdatesForType implements Datastore
-func (_d DatastoreWithPrometheus) GetUpdatesForType(dataType int, clientToken int64, fetchFolders bool, clientID string, maxSize int64) (i1 int64, sa1 []SyncEntity, err error) {
+func (_d DatastoreWithPrometheus) GetUpdatesForType(dataType int, clientToken int64, fetchFolders bool, clientID string, maxSize int64) (b1 bool, sa1 []SyncEntity, err error) {
 	_since := time.Now()
 	defer func() {
 		result := "ok"


### PR DESCRIPTION
Fix https://github.com/brave/go-sync/issues/29

This PR:
- Return changesRemaining = 1 when there are more updates in DB instead of actual count to follow what chromium does and save unnecessary read for items cannot be returned in this request.
- Set Query limit to remaining batch size to reduce unnecessary read.
- Update tests and instrumented files for above changes.
