### PR TITLE
Return CONFLICT for inserting items with duplicate client tags

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -220,10 +220,13 @@ func handleCommitRequest(cache *cache.Cache, commitMsg *sync_pb.CommitMessage, c
 				continue
 			}
 
-			err = db.InsertSyncEntity(entityToCommit)
+			conflict, err := db.InsertSyncEntity(entityToCommit)
 			if err != nil {
 				log.Error().Err(err).Msg("Insert sync entity failed")
 				rspType := sync_pb.CommitResponse_TRANSIENT_ERROR
+				if conflict {
+					rspType = sync_pb.CommitResponse_CONFLICT
+				}
 				entryRsp.ResponseType = &rspType
 				entryRsp.ErrorMessage = aws.String(fmt.Sprintf("Insert sync entity failed: %v", err.Error()))
 				continue

--- a/command/command.go
+++ b/command/command.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/brave/go-sync/cache"
@@ -163,6 +165,10 @@ func handleGetUpdatesRequest(cache *cache.Cache, guMsg *sync_pb.GetUpdatesMessag
 	return &errCode, nil
 }
 
+func shouldReturnConflict(clientID string) bool {
+	return clientID != "" && clientID == os.Getenv("ReturnConflictForClientTag")
+}
+
 // handleCommitRequest handles the commit message and fills the commit response.
 // For each commit entry:
 //   - new sync entity is created and inserted into the database if version is 0.
@@ -224,7 +230,8 @@ func handleCommitRequest(cache *cache.Cache, commitMsg *sync_pb.CommitMessage, c
 			if err != nil {
 				log.Error().Err(err).Msg("Insert sync entity failed")
 				rspType := sync_pb.CommitResponse_TRANSIENT_ERROR
-				if conflict {
+				if conflict && shouldReturnConflict(strings.ToUpper(clientID)) {
+					log.Error().Msg("CONFLICT returned for specific clients")
 					rspType = sync_pb.CommitResponse_CONFLICT
 				}
 				entryRsp.ResponseType = &rspType

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -627,8 +627,8 @@ func insertSyncEntitiesWithoutUpdateCache(
 	for _, entry := range entries {
 		dbEntry, err := datastore.CreateDBSyncEntity(entry, nil, clientID)
 		suite.Require().NoError(err, "Create db entity from pb entity should succeed")
-		suite.Require().NoError(suite.dynamo.InsertSyncEntity(dbEntry),
-			"Insert sync entity should succeed")
+		_, err = suite.dynamo.InsertSyncEntity(dbEntry)
+		suite.Require().NoError(err, "Insert sync entity should succeed")
 		val, err := suite.cache.Get(context.Background(),
 			clientID+"#"+strconv.Itoa(*dbEntry.DataType))
 		suite.Require().NoError(err, "Get from cache should succeed")

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -850,6 +850,11 @@ func (suite *CommandTestSuite) TestHandleClientToServerMessage_TypeMtimeCache_Ch
 		"cache should be updated when changes remaining = 0")
 }
 
+func (suite *CommandTestSuite) TestShouldReturnConflict() {
+	suite.Require().True(command.ShouldReturnConflict("TEST"))
+	suite.Require().False(command.ShouldReturnConflict("TEST2"))
+}
+
 func TestCommandTestSuite(t *testing.T) {
 	suite.Run(t, new(CommandTestSuite))
 }

--- a/command/export_test.go
+++ b/command/export_test.go
@@ -17,4 +17,5 @@ var (
 	SetSyncPollInterval        = setSyncPollInterval
 	MaxGUBatchSize             = &maxGUBatchSize
 	MaxClientObjectQuota       = &maxClientObjectQuota
+	ShouldReturnConflict       = shouldReturnConflict
 )

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -3,7 +3,7 @@ package datastore
 // Datastore abstracts over the underlying datastore.
 type Datastore interface {
 	// Insert a new sync entity.
-	InsertSyncEntity(entity *SyncEntity) error
+	InsertSyncEntity(entity *SyncEntity) (bool, error)
 	// Insert a series of sync entities in a write transaction.
 	InsertSyncEntitiesWithServerTags(entities []*SyncEntity) error
 	// Update an existing sync entity.

--- a/datastore/instrumented_datastore.go
+++ b/datastore/instrumented_datastore.go
@@ -94,7 +94,7 @@ func (_d DatastoreWithPrometheus) InsertSyncEntitiesWithServerTags(entities []*S
 }
 
 // InsertSyncEntity implements Datastore
-func (_d DatastoreWithPrometheus) InsertSyncEntity(entity *SyncEntity) (err error) {
+func (_d DatastoreWithPrometheus) InsertSyncEntity(entity *SyncEntity) (b1 bool, err error) {
 	_since := time.Now()
 	defer func() {
 		result := "ok"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - AWS_REGION=us-west-2
       - AWS_ENDPOINT=http://dynamo-local:8000
       - REDIS_URL=redis:6379
+      - ReturnConflictForClientTag=TEST
   web:
     build:
       context: .


### PR DESCRIPTION
We have seen cases that some clients kept getting TRANSIENT_ERROR when they trying to insert new items with duplicate client tags and cannot recover from it, and clients kept trying the same commits which cannot be accepted by the server due to duplicate client tags.
We are having a hard time to reproduce it, in theory we think return CONFLICT in this case makes more sense, the change is in the first commit of this PR.
The second commit is to limit the scope to specific clients first, and will be reverted pretty soon.