### PR TITLE
Return CONFLICT for all clients seeing tag conflict

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/brave/go-sync/cache"
@@ -165,10 +163,6 @@ func handleGetUpdatesRequest(cache *cache.Cache, guMsg *sync_pb.GetUpdatesMessag
 	return &errCode, nil
 }
 
-func shouldReturnConflict(clientID string) bool {
-	return clientID != "" && clientID == os.Getenv("ReturnConflictForClientTag")
-}
-
 // handleCommitRequest handles the commit message and fills the commit response.
 // For each commit entry:
 //   - new sync entity is created and inserted into the database if version is 0.
@@ -230,8 +224,7 @@ func handleCommitRequest(cache *cache.Cache, commitMsg *sync_pb.CommitMessage, c
 			if err != nil {
 				log.Error().Err(err).Msg("Insert sync entity failed")
 				rspType := sync_pb.CommitResponse_TRANSIENT_ERROR
-				if conflict && shouldReturnConflict(strings.ToUpper(clientID)) {
-					log.Error().Msg("CONFLICT returned for specific clients")
+				if conflict {
 					rspType = sync_pb.CommitResponse_CONFLICT
 				}
 				entryRsp.ResponseType = &rspType

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -850,11 +850,6 @@ func (suite *CommandTestSuite) TestHandleClientToServerMessage_TypeMtimeCache_Ch
 		"cache should be updated when changes remaining = 0")
 }
 
-func (suite *CommandTestSuite) TestShouldReturnConflict() {
-	suite.Require().True(command.ShouldReturnConflict("TEST"))
-	suite.Require().False(command.ShouldReturnConflict("TEST2"))
-}
-
 func TestCommandTestSuite(t *testing.T) {
 	suite.Run(t, new(CommandTestSuite))
 }

--- a/command/export_test.go
+++ b/command/export_test.go
@@ -17,5 +17,4 @@ var (
 	SetSyncPollInterval        = setSyncPollInterval
 	MaxGUBatchSize             = &maxGUBatchSize
 	MaxClientObjectQuota       = &maxClientObjectQuota
-	ShouldReturnConflict       = shouldReturnConflict
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
       - AWS_REGION=us-west-2
       - AWS_ENDPOINT=http://dynamo-local:8000
       - REDIS_URL=redis:6379
-      - ReturnConflictForClientTag=TEST
   web:
     build:
       context: .


### PR DESCRIPTION
This PR just remove our commit for limiting this change to some specific client.
This reverts commit 8167969c85db3e90e2528823710d1e2ab8a10062.