### PR TITLE
Increase ttl of keys in redis cache from 5 mins to 10 mins

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	ttl = 300 * time.Second
+	ttl = 600 * time.Second
 )
 
 // Cache is a wrapper for cache accesses.


### PR DESCRIPTION
Fixed https://github.com/brave/go-sync/issues/88