### PR TITLE
Move Auth middleware under /v2

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/brave/go-sync/command"
 	syncContext "github.com/brave/go-sync/context"
 	"github.com/brave/go-sync/datastore"
+	syncMiddleware "github.com/brave/go-sync/middleware"
 	"github.com/brave/go-sync/schema/protobuf/sync_pb"
 	"github.com/go-chi/chi"
 	"github.com/rs/zerolog/log"
@@ -25,6 +26,8 @@ const (
 // SyncRouter add routers for command and auth endpoint requests.
 func SyncRouter(cache *cache.Cache, datastore datastore.Datastore) chi.Router {
 	r := chi.NewRouter()
+	r.Use(syncMiddleware.Auth)
+	r.Use(syncMiddleware.DisabledChain)
 	r.Method("POST", "/command/", middleware.InstrumentHandler("Command", Command(cache, datastore)))
 	return r
 }

--- a/server/server.go
+++ b/server/server.go
@@ -55,8 +55,6 @@ func setupRouter(ctx context.Context, logger *zerolog.Logger) (context.Context, 
 	r.Use(chiware.Timeout(60 * time.Second))
 	r.Use(batware.BearerToken)
 	r.Use(middleware.CommonResponseHeaders)
-	r.Use(middleware.Auth)
-	r.Use(middleware.DisabledChain)
 
 	db, err := datastore.NewDynamo()
 	if err != nil {


### PR DESCRIPTION
Auth middleware at the top level blocked health check and metrics endpoints.  This moves auth and disabled chain middleware under `/v2` path.