### PR TITLE
Revert "Add validation for `SpecificsVariant`"

### DIFF
--- a/datastore/sync_entity.go
+++ b/datastore/sync_entity.go
@@ -16,7 +16,7 @@ import (
 	"github.com/brave/go-sync/schema/protobuf/sync_pb"
 	"github.com/brave/go-sync/utils"
 	"github.com/rs/zerolog/log"
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -500,10 +500,6 @@ func validatePBEntity(entity *sync_pb.SyncEntity) error {
 
 	if entity.Specifics == nil {
 		return fmt.Errorf("validate SyncEntity error: nil Specifics")
-	}
-
-	if entity.Specifics.SpecificsVariant == nil {
-		return fmt.Errorf("validate SyncEntity error: nil SpecificsVariant")
 	}
 
 	return nil

--- a/datastore/sync_entity_test.go
+++ b/datastore/sync_entity_test.go
@@ -616,12 +616,6 @@ func (suite *SyncEntityTestSuite) TestCreateDBSyncEntity() {
 	pbEntity.Specifics = nil
 	_, err = datastore.CreateDBSyncEntity(&pbEntity, guid, "client1")
 	suite.Assert().NotNil(err.Error(), "empty specifics should fail")
-
-	// Empty specifics variant should report marshal error.
-	specifics = &sync_pb.EntitySpecifics{}
-	pbEntity.Specifics = nil
-	_, err = datastore.CreateDBSyncEntity(&pbEntity, guid, "client1")
-	suite.Assert().NotNil(err.Error(), "empty specifics variant should fail")
 }
 
 func (suite *SyncEntityTestSuite) TestCreatePBSyncEntity() {


### PR DESCRIPTION
Reverts brave/go-sync#131

After further investigation we found this to be related to outdated proto files.