### PR TITLE
DRAFT: added documentation for self-hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Currently we use dynamoDB as the datastore, the schema could be found in `schema
 3. Run `make docker-up`
 4. For running unit tests, run `make docker-test`
 
-# Updating protocol definitions
+## Updating protocol definitions
 1. Copy the `.proto` files from `components/sync/protocol` in `chromium` to `schema/protobuf/sync_pb` in `go-sync`.
 2. Copy the `.proto` files from `components/sync/protocol` in `brave-core` to `schema/protobuf/sync_pb` in `go-sync`.
 3. Run `make repath-proto` to set correct import paths in `.proto` files.
@@ -38,3 +38,45 @@ make instrumented
 ```
 
 Changes to `datastore/datastore.go` or `cache/cache.go` should be followed with the above command.
+
+## Self-hosting
+
+### Setting up the servers with persistant storage
+1. Run the folling commands to get two containers, `brave-sync:latest` and `brave-dynamo:latest`:
+    ```
+    GIT_VERSION=$(git describe --abbrev=8 --dirty --always --tags)
+    GIT_COMMIT=$(git rev-parse --short HEAD)
+    BUILD_TIME=$(date +%s)
+    docker-compose build
+    docker tag go-sync_web:latest brave-sync:latest
+    docker tag go-sync_dynamo-local:latest brave-dynamo:latest
+    ```
+2. Copy the `docker-compose-self-host.yml` to whevever you wish to host your project as a `docker-compose.yml` file.
+3. On your server, get a copy of the initial Brave Sync Dynamo DB out of the container:
+    ```
+    docker run --rm -t --name get-db -d brave-dynamo:latest
+    mkdir -p /data/containers/brave/dynamo
+    docker cp get-db:/db/shared-local-instance.db /data/containers/brave/dynamo/
+    docker stop get-db
+    chown 1000:1000 /data/containers/brave/dynamo/ -R
+    ```
+4. Either uncomment the `ports` section in the docker compose file and point your SSL proxy to `http://localhost:8295`, or run the SSL proxy inside the `brave` docker network and point it to `http://brave-sync:8295`.
+5. Change the `SET_TO_SOMETHING_SECURE` value to something secure.
+6. Run `docker compose up` from that new server.
+
+### Using clients
+
+#### Desktop
+This command line option must be supplied every time you start Brave.
+1. Start with `--sync-url="https://my.brave.sync.url/v2"`
+2. Confirm the setting by visiting `brave://sync-internals/`
+
+#### Android
+This setting may not persist after a reboot on all devices, use at your own risk. Work is ongoing for a more formal way to [persist the sync URL](https://github.com/brave/brave-browser/issues/12314).
+1. Enable `brave://flags/#enable-command-line-on-non-rooted-devices`
+2. Create `/data/local/tmp/chrome-command-line` and add `--sync-url=https://my.brave.sync.url/v2` to it starting with an underscore over adb:
+    ```
+    adb shell
+    echo "_ --sync-url=https://my.brave.sync.url/v2" > /data/local/tmp/chrome-command-line
+    ```
+3. Set up sync as normal on the device

--- a/docker-compose-self-host.yml
+++ b/docker-compose-self-host.yml
@@ -1,0 +1,51 @@
+version: '3.8'
+
+services:
+
+  brave-sync:
+    image: brave-sync:latest
+    container_name: brave-sync
+    environment:
+      - PPROF_ENABLED=true
+      - SENTRY_DSN
+      - ENV=local
+      - DEBUG=1
+      - AWS_ACCESS_KEY_ID=SET_TO_SOMETHING_SECURE
+      - AWS_SECRET_ACCESS_KEY=SET_TO_SOMETHING_SECURE
+      - AWS_REGION=us-west-2
+      - AWS_ENDPOINT=http://brave-dynamo:8000
+      - TABLE_NAME=client-entity-dev
+      - REDIS_URL=brave-redis:6379
+    depends_on:
+      - brave-dynamo
+      - brave-redis
+    restart: unless-stopped
+    networks:
+      - brave
+    # Uncomment these if you are not using an HTTPS proxy
+    # in the same `brave` network.
+    # ports:
+    #   - "8295:8295"
+
+  brave-dynamo:
+    image: brave-dynamo:latest
+    environment:
+      - AWS_ACCESS_KEY_ID=SET_TO_SOMETHING_SECURE
+      - AWS_SECRET_ACCESS_KEY=SET_TO_SOMETHING_SECURE
+    volumes:
+      # If desired, change this path
+      - /data/containers/brave/dynamo:/db
+    restart: unless-stopped
+    networks:
+      - brave
+
+  brave-redis:
+    image: public.ecr.aws/ubuntu/redis:latest
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    networks:
+      - brave
+
+networks:
+  brave:
+    name: brave


### PR DESCRIPTION
This PR adds a Docker Compose file and documentation in the `README` to provide guidance on how users can set up their self-hosted systems.

Looking for feedback from the Brave team on if this is acceptable or if there are other configurations that should be considered.