### PR TITLE
Increase storage from 50k to 75k objects

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -15,7 +15,7 @@ import (
 var (
 	// Could be modified in tests.
 	maxGUBatchSize       = 500
-	maxClientObjectQuota = 50000
+	maxClientObjectQuota = 75000
 )
 
 const (


### PR DESCRIPTION
Resolves https://github.com/brave/go-sync/issues/198

### Description

By the reason of issue with [Wrong History object calculation for P3A](https://github.com/brave/brave-browser/issues/35579) I missed the moment when many users had reached the limit of synced objects per chain on the server. Their devices received `OVER_QUOTA` error on commit and Sync stopped to work.

This PR increases limit of synced objects on the server from 50k to 75k and among others PRs must improve the situation.

### Test plan

1. Configure Browser sync against the local server limit 50000, enable history and bookmarks;
2. Create 50000 history entries, ensure the server is overfilled
Open brave://inspect/#extensions , click `inspect` near the Brave extension, paste
```
for (i=0;i<50001;++i) chrome.history.addUrl({url: 'https://search.brave.com/search?q='+i+'&source=web'}, function() {})
```
into the console
3. Shotdown server, close browser
4. Change server limit to 75k, rebuild and start server
5. Launch browser
6. Ensure server accepts the records from the client

### Screenshots
#|Description|Screenshot
--|--|--
1|Normal History commits, not yet reached the 50k limit|![Screenshot from 2024-01-31 20-17-17](https://github.com/brave/go-sync/assets/24739341/bf59614a-270b-4367-b496-5bff017ff0b7)
2|TRANSIENT_ERROR, reached server limit|![Screenshot from 2024-01-31 20-30-49](https://github.com/brave/go-sync/assets/24739341/2c320bbd-dbdc-4589-9518-0ff521873997)
3|Re-built server with increased to 75k objects limit, re-started browser|![Screenshot from 2024-01-31 20-33-34](https://github.com/brave/go-sync/assets/24739341/643c64c2-7944-4944-8a26-f1befe58aa37)

