### PR TITLE
Decrease expiration period for history from 90 to 60 days

### DIFF
--- a/datastore/sync_entity.go
+++ b/datastore/sync_entity.go
@@ -32,7 +32,7 @@ const (
 	historyDeleteDirectiveTypeID int = 150251
 	// Expiration time for history and history delete directive
 	// entities in seconds
-	HistoryExpirationIntervalSecs = 60 * 60 * 24 * 90 // 90 days
+	HistoryExpirationIntervalSecs = 60 * 60 * 24 * 30 // 30 days
 )
 
 // SyncEntity is used to marshal and unmarshal sync items in dynamoDB.

--- a/datastore/sync_entity.go
+++ b/datastore/sync_entity.go
@@ -32,7 +32,7 @@ const (
 	historyDeleteDirectiveTypeID int = 150251
 	// Expiration time for history and history delete directive
 	// entities in seconds
-	HistoryExpirationIntervalSecs = 60 * 60 * 24 * 30 // 30 days
+	HistoryExpirationIntervalSecs = 60 * 60 * 24 * 60 // 60 days
 )
 
 // SyncEntity is used to marshal and unmarshal sync items in dynamoDB.


### PR DESCRIPTION
Resolves https://github.com/brave/go-sync/issues/199

Decrease expiration period for history from 90 to 60 days