### PR TITLE
docker-compose to docker compose to unbreak CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,13 @@ clean:
 	rm -f sync-server
 
 docker:
-	COMMIT=$(GIT_COMMIT) VERSION=$(GIT_VERSION) BUILD_TIME=$(BUILD_TIME) docker-compose build
+	COMMIT=$(GIT_COMMIT) VERSION=$(GIT_VERSION) BUILD_TIME=$(BUILD_TIME) docker compose build
 
 docker-up:
-	COMMIT=$(GIT_COMMIT) VERSION=$(GIT_VERSION) BUILD_TIME=$(BUILD_TIME) docker-compose up
+	COMMIT=$(GIT_COMMIT) VERSION=$(GIT_VERSION) BUILD_TIME=$(BUILD_TIME) docker compose up
 
 docker-test:
-	COMMIT=$(GIT_COMMIT) VERSION=$(GIT_VERSION) BUILD_TIME=$(BUILD_TIME) docker-compose -f docker-compose.yml run --rm dev make test
+	COMMIT=$(GIT_COMMIT) VERSION=$(GIT_VERSION) BUILD_TIME=$(BUILD_TIME) docker compose -f docker-compose.yml run --rm dev make test
 
 instrumented:
 	gowrap gen -p github.com/brave/go-sync/datastore -i Datastore -t ./.prom-gowrap.tmpl -o ./datastore/instrumented_datastore.go


### PR DESCRIPTION
```
Run make docker && make docker-test
  make docker && make docker-test
  shell: /usr/bin/bash -e {0}
COMMIT=f76c5d8 VERSION=f76c5d8b BUILD_TIME=17[2](https://github.com/brave/go-sync/actions/runs/10379488811/job/28737743260?pr=285#step:5:2)3596675 docker-compose build
/bin/sh: 1: docker-compose: not found
make: *** [Makefile:[3](https://github.com/brave/go-sync/actions/runs/10379488811/job/28737743260?pr=285#step:5:3)2: docker] Error 127
Error: Process completed with exit code 2.
```